### PR TITLE
remove .git suffix while creating project dir in gclone

### DIFF
--- a/cdgo.sh
+++ b/cdgo.sh
@@ -3,42 +3,49 @@
 
 # cdsk sujaykumarsuman
 cdsk() {
-  if [ $# -eq 0 ]; then
-    echo "Please provide repository name"
-    return
-  fi
-  cd $GOPATH/src/github.com/sujaykumarsuman/$1
+  cd "$GOPATH/src/github.com/sujaykumarsuman/$1"
 }
 
 _cdsk_completion() {
+  local projects
+  projects=($(command ls "$GOPATH/src/github.com/sujaykumarsuman" 2>/dev/null))
+  compadd -- "${projects[@]}"
+}
+
+_cdsk_bash_completion() {
   if [ "${#COMP_WORDS[@]}" != "2" ]; then
     return
   fi
-
-  projects=$(ls $GOPATH/src/github.com/sujaykumarsuman)
-
+  local projects
+  projects=$(command ls "$GOPATH/src/github.com/sujaykumarsuman" 2>/dev/null)
   COMPREPLY=($(compgen -W "${projects}" -- "${COMP_WORDS[1]}"))
 }
-
-complete -F _cdsk_completion cdsk
 
 # skriptvalley
 cdvalley() {
-  if [ $# -eq 0 ]; then
-    echo "Please provide repository name"
-    return
-  fi
-  cd $GOPATH/src/github.com/skriptvalley/$1
+  cd "$GOPATH/src/github.com/skriptvalley/$1"
 }
 
 _cdvalley_completion() {
+  local projects
+  projects=($(command ls "$GOPATH/src/github.com/skriptvalley" 2>/dev/null))
+  compadd -- "${projects[@]}"
+}
+
+_cdvalley_bash_completion() {
   if [ "${#COMP_WORDS[@]}" != "2" ]; then
     return
   fi
-
-  projects=$(ls $GOPATH/src/github.com/skriptvalley)
-
+  local projects
+  projects=$(command ls "$GOPATH/src/github.com/skriptvalley" 2>/dev/null)
   COMPREPLY=($(compgen -W "${projects}" -- "${COMP_WORDS[1]}"))
 }
 
-complete -F _cdvalley_completion cdvalley
+# Register completions
+if [[ -n $ZSH_VERSION ]]; then
+  compdef _cdsk_completion cdsk
+  compdef _cdvalley_completion cdvalley
+else
+  complete -F _cdsk_bash_completion cdsk
+  complete -F _cdvalley_bash_completion cdvalley
+fi

--- a/gitshorts.sh
+++ b/gitshorts.sh
@@ -14,6 +14,9 @@ gclone() {
     repo_url=$1
     remote=$(echo $repo_url | cut -d':' -f1)
     repo=$(echo $repo_url | cut -d':' -f2-)
+
+    # remove the .git suffix if it exists
+    repo=$(echo $repo | sed 's/\.git$//')
     
     # Create the necessary directories if they do not exist
     mkdir -p $HOME/go/src/$remote


### PR DESCRIPTION
Fix the issue where .git suffix persist while creating the project dir